### PR TITLE
PN-16241: Return 409 conflict for duplicate presignedUrl request.

### DIFF
--- a/src/main/java/it/pagopa/pn/service/desk/exception/ExceptionTypeEnum.java
+++ b/src/main/java/it/pagopa/pn/service/desk/exception/ExceptionTypeEnum.java
@@ -13,6 +13,7 @@ public enum ExceptionTypeEnum {
     ADDRESS_IS_NOT_VALID("ADDRESS_IS_NOT_VALID", "l'indirizzo non è valido"),
     OPERATION_ID_IS_PRESENT("OPERATION_ID_IS_PRESENT", "The operation id is already present for the ticket id "),
     OPERATION_IS_NOT_PRESENT("OPERATION_IS_NOT_PRESENT", "L'operation non è presente"),
+    FILE_ALREADY_UPLOADED("FILE_ALREADY_UPLOADED", "Il file è già stato caricato per questo operationId"),
     ERROR_CONTENT_TYPE("ERROR_CONTENT_TYPE", "contentType non valido"),
     ERROR_DURING_VIDEO_UPLOAD("ERROR_DURING_VIDEO_UPLOAD", "Errore durante l'upload del video"),
     ERROR_PRESIGNED_URL_VIDEO_UPLOAD("ERROR_PRESIGNED_URL_UPLOAD", "ERROR_PRESIGNED_URL_UPLOAD"),


### PR DESCRIPTION
Return 409 conflict for duplicate presignedUrl requests and update status to VALIDATION

- Return HTTP 409 CONFLICT when presignedUrl already requested for operationId (operation not in CREATING status)
- Update operation status to VALIDATION after successful presignedUrl generation
- Add comprehensive JUnit tests to verify both functionalities