### PR TITLE
PN-18975: Fix status conversion in external channel response handler

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -41,6 +41,8 @@ pn.service-desk.product-type=RS
 pn.service-desk.topics.internal-queue=local-service-desk-internal
 pn.service-desk.topics.paperchannel-queue=local-pn-paperchannel_to_servicedesk
 pn.service-desk.topics.externalchannel-queue=local-pn-externalchannel_to_servicedesk
+pn.service-desk.external-channel-digital-codes-success[0]=M003
+pn.service-desk.external-channel-digital-codes-failure=M008,M009,M010,M011
 
 
 # Queue inbound event configuration

--- a/src/main/java/it/pagopa/pn/service/desk/action/impl/ResultExternalChannelActionImpl.java
+++ b/src/main/java/it/pagopa/pn/service/desk/action/impl/ResultExternalChannelActionImpl.java
@@ -3,10 +3,10 @@ package it.pagopa.pn.service.desk.action.impl;
 
 import it.pagopa.pn.service.desk.action.ResultExternalChannelAction;
 import it.pagopa.pn.service.desk.action.common.CommonAction;
+import it.pagopa.pn.service.desk.config.PnServiceDeskConfigs;
 import it.pagopa.pn.service.desk.exception.PnEntityNotFoundException;
 import it.pagopa.pn.service.desk.exception.PnGenericException;
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pnexternalchannel.v1.dto.CourtesyMessageProgressEventDto;
-import it.pagopa.pn.service.desk.generated.openapi.msclient.pnexternalchannel.v1.dto.ProgressEventCategoryDto;
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pnexternalchannel.v1.dto.SingleStatusUpdateDto;
 import it.pagopa.pn.service.desk.middleware.db.dao.OperationDAO;
 import it.pagopa.pn.service.desk.middleware.entities.PnServiceDeskOperations;
@@ -32,6 +32,7 @@ import static it.pagopa.pn.service.desk.exception.ExceptionTypeEnum.EXTERNALCHAN
 public class ResultExternalChannelActionImpl extends CommonAction implements ResultExternalChannelAction {
 
     private OperationDAO operationDAO;
+    private PnServiceDeskConfigs cfg;
 
     @Override
     public void execute(SingleStatusUpdateDto singleStatusUpdateDto) {
@@ -47,13 +48,13 @@ public class ResultExternalChannelActionImpl extends CommonAction implements Res
         operationDAO.getByOperationId(operationId)
             .switchIfEmpty(Mono.error(new PnEntityNotFoundException()))
             .flatMap(entityOperation -> {
-                if (StringUtils.isBlank(courtesyMessageProgressEventDto.getStatus().getValue())) {
+                if (StringUtils.isBlank(courtesyMessageProgressEventDto.getEventCode().getValue())) {
                     log.error("entityOperation = {}, operationId = {}, Status code is null or blank", entityOperation, operationId);
                     return Mono.error(new PnGenericException(EXTERNALCHANNEL_STATUS_CODE_EMPTY, EXTERNALCHANNEL_STATUS_CODE_EMPTY.getMessage()));
                 }
-                OperationStatusEnum newStatus = Utility.getEcOperationStatusFrom(courtesyMessageProgressEventDto.getStatus());
+                OperationStatusEnum newStatus = convertExternalChannelStatusToOperationStatus(courtesyMessageProgressEventDto.getEventCode());
                 entityOperation.setStatus(newStatus.name());
-                if ( courtesyMessageProgressEventDto.getStatus().equals(ProgressEventCategoryDto.OK)){
+                if ( newStatus.equals(OperationStatusEnum.OK) ) {
                 log.info("entityOperation = {}, operationId = {}, Status code is OK, updating operation status to {}", entityOperation, operationId, newStatus);
                 } else {
                     log.warn("entityOperation = {}, operationId = {}, Status code is not OK, updating operation status to {}", entityOperation, operationId, newStatus);
@@ -75,6 +76,14 @@ public class ResultExternalChannelActionImpl extends CommonAction implements Res
                         return Mono.empty();
                     }
                 }).block();
+    }
+
+    private OperationStatusEnum convertExternalChannelStatusToOperationStatus(CourtesyMessageProgressEventDto.EventCodeEnum status) {
+        if (cfg.getExternalChannelDigitalCodesSuccess().contains(status.getValue()))
+            return OperationStatusEnum.OK;
+        if (cfg.getExternalChannelDigitalCodesFailure().contains(status.getValue()))
+            return OperationStatusEnum.KO;
+        return OperationStatusEnum.PROGRESS;
     }
 
     private Mono<Void> updateParentAggregateStatus(PnServiceDeskOperations subOp) {

--- a/src/main/java/it/pagopa/pn/service/desk/config/PnServiceDeskConfigs.java
+++ b/src/main/java/it/pagopa/pn/service/desk/config/PnServiceDeskConfigs.java
@@ -47,6 +47,8 @@ public class PnServiceDeskConfigs {
     private Integer notifyAttempt;
     private Integer maxNumberOfPages;
     private List<String> documentTypeFilter = new ArrayList<>();
+    private List<String> externalChannelDigitalCodesSuccess;
+    private List<String> externalChannelDigitalCodesFailure;
 
     @Data
     public static class Topics {

--- a/src/main/java/it/pagopa/pn/service/desk/utility/Utility.java
+++ b/src/main/java/it/pagopa/pn/service/desk/utility/Utility.java
@@ -1,6 +1,5 @@
 package it.pagopa.pn.service.desk.utility;
 
-import it.pagopa.pn.service.desk.generated.openapi.msclient.pnexternalchannel.v1.dto.ProgressEventCategoryDto;
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pnpaperchannel.v1.dto.StatusCodeEnumDto;
 import it.pagopa.pn.service.desk.model.OperationStatusEnum;
 import org.apache.commons.lang3.StringUtils;
@@ -44,24 +43,12 @@ public class Utility {
         return getStatusMapping().get(statusCodePaperChannel);
     }
 
-public static OperationStatusEnum getEcOperationStatusFrom(ProgressEventCategoryDto statusCodeExternalChannel){
-        return getEcStatusMapping().get(statusCodeExternalChannel);
-}
-
     private static Map<StatusCodeEnumDto, OperationStatusEnum> getStatusMapping(){
         Map<StatusCodeEnumDto, OperationStatusEnum> status = new EnumMap<>(StatusCodeEnumDto.class);
         status.put(StatusCodeEnumDto.KO, OperationStatusEnum.KO);
         status.put(StatusCodeEnumDto.KOUNREACHABLE, OperationStatusEnum.KO);
         status.put(StatusCodeEnumDto.OK, OperationStatusEnum.OK);
         status.put(StatusCodeEnumDto.PROGRESS, OperationStatusEnum.PROGRESS);
-        return status;
-    }
-
-    private static Map<ProgressEventCategoryDto, OperationStatusEnum> getEcStatusMapping(){
-        Map<ProgressEventCategoryDto, OperationStatusEnum> status = new EnumMap<>(ProgressEventCategoryDto.class);
-        status.put(ProgressEventCategoryDto.ERROR, OperationStatusEnum.KO);
-        status.put(ProgressEventCategoryDto.OK, OperationStatusEnum.OK);
-        status.put(ProgressEventCategoryDto.PROGRESS, OperationStatusEnum.PROGRESS);
         return status;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,10 @@ pn.service-desk.sender-address.city=Roma
 pn.service-desk.sender-address.pr=Roma
 pn.service-desk.sender-address.country=Italia
 
+# External Channel configuration
+pn.service-desk.external-channel-digital-codes-success[0]=M003
+pn.service-desk.external-channel-digital-codes-failure=M008,M009,M010,M011
+
 pn.service-desk.notify-attempt=2
 pn.service-desk.max-number-of-pages=3
 

--- a/src/test/java/it/pagopa/pn/service/desk/action/impl/ResultExternalChannelActionImplTest.java
+++ b/src/test/java/it/pagopa/pn/service/desk/action/impl/ResultExternalChannelActionImplTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.pn.service.desk.action.impl;
 
+import it.pagopa.pn.service.desk.config.PnServiceDeskConfigs;
 import it.pagopa.pn.service.desk.exception.PnGenericException;
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pnexternalchannel.v1.dto.CourtesyMessageProgressEventDto;
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pnexternalchannel.v1.dto.ProgressEventCategoryDto;
@@ -7,6 +8,7 @@ import it.pagopa.pn.service.desk.generated.openapi.msclient.pnexternalchannel.v1
 import it.pagopa.pn.service.desk.middleware.db.dao.OperationDAO;
 import it.pagopa.pn.service.desk.middleware.entities.PnServiceDeskOperations;
 import it.pagopa.pn.service.desk.model.OperationStatusEnum;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
@@ -28,12 +30,22 @@ class ResultExternalChannelActionImplTest {
     @Mock
     private OperationDAO operationDAO;
 
-    private SingleStatusUpdateDto getDto(String operationId, ProgressEventCategoryDto status) {
+    @Mock
+    private PnServiceDeskConfigs cfg;
+
+    @BeforeEach
+    void setup() {
+        Mockito.lenient().when(cfg.getExternalChannelDigitalCodesSuccess()).thenReturn(List.of(CourtesyMessageProgressEventDto.EventCodeEnum.M003.getValue()));
+        Mockito.lenient().when(cfg.getExternalChannelDigitalCodesFailure()).thenReturn(List.of(CourtesyMessageProgressEventDto.EventCodeEnum.M008.getValue()));
+    }
+
+    private SingleStatusUpdateDto getDto(String operationId, ProgressEventCategoryDto status, CourtesyMessageProgressEventDto.EventCodeEnum eventCode) {
         SingleStatusUpdateDto singleStatusUpdateDto = new SingleStatusUpdateDto();
 
         CourtesyMessageProgressEventDto dto = new CourtesyMessageProgressEventDto();
         dto.setRequestId("SERVICE_DESK_OPID-" + operationId);
         dto.setStatus(status);
+        dto.setEventCode(eventCode);
 
         singleStatusUpdateDto.setDigitalCourtesy(dto);
         return singleStatusUpdateDto;
@@ -41,7 +53,7 @@ class ResultExternalChannelActionImplTest {
 
     @Test
     void testExecute_entityNotFound() {
-        SingleStatusUpdateDto dto = getDto("NOT_FOUND", ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto("NOT_FOUND", ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
 
         when(operationDAO.getByOperationId("NOT_FOUND")).thenReturn(Mono.empty());
 
@@ -52,7 +64,7 @@ class ResultExternalChannelActionImplTest {
     @Test
     void testExecute_statusCodeEmpty() {
         // Arrange
-        SingleStatusUpdateDto dto = getDto("QWERTY", null); // status è null
+        SingleStatusUpdateDto dto = getDto("QWERTY", null, null); // status è null
         PnServiceDeskOperations entity = new PnServiceDeskOperations();
 
         when(operationDAO.getByOperationId("QWERTY")).thenReturn(Mono.just(entity));
@@ -64,7 +76,7 @@ class ResultExternalChannelActionImplTest {
 
     @Test
     void testExecute_statusCodeOk() {
-        SingleStatusUpdateDto dto = getDto("OK123", ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto("OK123", ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
         PnServiceDeskOperations entity = new PnServiceDeskOperations();
 
         when(operationDAO.getByOperationId("OK123")).thenReturn(Mono.just(entity));
@@ -77,7 +89,7 @@ class ResultExternalChannelActionImplTest {
 
     @Test
     void testExecute_statusCodeKo() {
-        SingleStatusUpdateDto dto = getDto("KO123", ProgressEventCategoryDto.ERROR);
+        SingleStatusUpdateDto dto = getDto("KO123", ProgressEventCategoryDto.ERROR, CourtesyMessageProgressEventDto.EventCodeEnum.M008);
         PnServiceDeskOperations entity = new PnServiceDeskOperations();
 
         when(operationDAO.getByOperationId("KO123")).thenReturn(Mono.just(entity));
@@ -90,7 +102,7 @@ class ResultExternalChannelActionImplTest {
 
     @Test
     void testExecute_unexpectedError() {
-        SingleStatusUpdateDto dto = getDto("ERR123", ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto("ERR123", ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
 
         when(operationDAO.getByOperationId("ERR123")).thenReturn(Mono.error(new RuntimeException("Boom")));
 
@@ -100,7 +112,7 @@ class ResultExternalChannelActionImplTest {
 
     @Test
     void testExecute_genericException() {
-        SingleStatusUpdateDto dto = getDto("GEN123", ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto("GEN123", ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
 
         when(operationDAO.getByOperationId("GEN123")).thenReturn(Mono.error(new PnGenericException(EXTERNALCHANNEL_STATUS_CODE_EMPTY, "status code empty")));
 
@@ -111,7 +123,7 @@ class ResultExternalChannelActionImplTest {
     @Test
     void testExecute_subOp_allOk_updatesParentOk() {
         String subOpId = "SUB#parentId#IUN-001";
-        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
 
         PnServiceDeskOperations subOp = new PnServiceDeskOperations();
         subOp.setOperationId(subOpId);
@@ -143,7 +155,7 @@ class ResultExternalChannelActionImplTest {
     @Test
     void testExecute_subOp_mixedResult_updatesParentWarning() {
         String subOpId = "SUB#parentId#IUN-001";
-        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
 
         PnServiceDeskOperations subOp = new PnServiceDeskOperations();
         subOp.setOperationId(subOpId);
@@ -175,7 +187,7 @@ class ResultExternalChannelActionImplTest {
     @Test
     void testExecute_subOp_allKo_updatesParentKo() {
         String subOpId = "SUB#parentId#IUN-001";
-        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.ERROR);
+        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.ERROR, CourtesyMessageProgressEventDto.EventCodeEnum.M008);
 
         PnServiceDeskOperations subOp = new PnServiceDeskOperations();
         subOp.setOperationId(subOpId);
@@ -207,7 +219,7 @@ class ResultExternalChannelActionImplTest {
     @Test
     void testExecute_subOp_notAllDone_doesNotUpdateParent() {
         String subOpId = "SUB#parentId#IUN-001";
-        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto(subOpId, ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
 
         PnServiceDeskOperations subOp = new PnServiceDeskOperations();
         subOp.setOperationId(subOpId);
@@ -235,7 +247,7 @@ class ResultExternalChannelActionImplTest {
 
     @Test
     void testExecute_nonSubOp_doesNotUpdateParent() {
-        SingleStatusUpdateDto dto = getDto("LEGACYOP", ProgressEventCategoryDto.OK);
+        SingleStatusUpdateDto dto = getDto("LEGACYOP", ProgressEventCategoryDto.OK, CourtesyMessageProgressEventDto.EventCodeEnum.M003);
 
         PnServiceDeskOperations legacyOp = new PnServiceDeskOperations();
         legacyOp.setOperationId("LEGACYOP");


### PR DESCRIPTION
   - Previously, operation status was derived from the external status which is subject to change. It is more correct to evaluate the logical status based on specific EventCodeEnum values (M003 for success, M008-M011 for failure), making the mapping configurable via application properties.
   - Remove unused getEcOperationStatusFrom method from Utility.