### PR TITLE
PN-14813: Fix iun enhancement in search operation

### DIFF
--- a/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
@@ -278,7 +278,7 @@ public class OperationsServiceImpl implements OperationsService {
     private Mono<OperationResponse> enhanceIuns(List<PnServiceDeskAttachments> attachments, OperationResponse operationResponse) {
         return Flux.fromIterable(attachments)
                 .flatMap(att -> pnDeliveryClient.getSentNotificationPrivate(att.getIun())
-                        .map(sentNotification -> {
+                        .doOnNext(sentNotification -> {
                             SDNotificationSummary summary = new SDNotificationSummary();
                             summary.setIun(sentNotification.getIun());
                             summary.setSenderPaInternalId(sentNotification.getSenderPaId());
@@ -290,7 +290,6 @@ public class OperationsServiceImpl implements OperationsService {
                             } else {
                                 operationResponse.getUncompletedIuns().add(summary);
                             }
-                            return sentNotification;
                         }))
                 .then(Mono.just(operationResponse));
     }

--- a/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
@@ -24,11 +24,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -248,11 +248,16 @@ public class OperationsServiceImpl implements OperationsService {
         return dataVaultClient.anonymized(searchNotificationRequest.getTaxId())
                 .flatMapMany(operationDAO::searchOperationsFromRecipientInternalId)
                 .filter(operation -> !Boolean.TRUE.equals(operation.getIsSubOperation()))
-                .map(pnServiceDeskOperations -> Tuples.of(
-                        Objects.requireNonNullElse(pnServiceDeskOperations.getAttachments(), new ArrayList<PnServiceDeskAttachments>()),
-                        OperationMapper.operationResponseMapper(pnServiceDeskOperations, searchNotificationRequest.getTaxId())
-                ))
-                .flatMap(tuple -> enhanceIuns(tuple.getT1(), tuple.getT2()))
+                .flatMap(pnServiceDeskOperations -> {
+                    OperationResponse operationResponse = OperationMapper.operationResponseMapper(pnServiceDeskOperations, searchNotificationRequest.getTaxId());
+                    List<String> subOpIds = pnServiceDeskOperations.getSubOperationsIds();
+                    if (!CollectionUtils.isEmpty(subOpIds)) {
+                        return enhanceIunsFromSubOperations(subOpIds, operationResponse);
+                    } else {
+                        List<PnServiceDeskAttachments> attachments = Objects.requireNonNullElse(pnServiceDeskOperations.getAttachments(), new ArrayList<>());
+                        return enhanceIuns(attachments, operationResponse);
+                    }
+                })
                 .collectSortedList((op1, op2) ->
                         (op2.getOperationUpdateTimestamp() != null ? op2.getOperationUpdateTimestamp()  : OffsetDateTime.now())
                                 .compareTo((op1.getOperationUpdateTimestamp() != null ? op1.getOperationUpdateTimestamp()  : OffsetDateTime.now())))
@@ -262,23 +267,32 @@ public class OperationsServiceImpl implements OperationsService {
                 });
     }
 
+    private Mono<OperationResponse> enhanceIunsFromSubOperations(List<String> subOpIds, OperationResponse operationResponse) {
+        return Flux.fromIterable(subOpIds)
+                .flatMap(operationDAO::getByOperationId)
+                .filter(subOp -> StringUtils.isNotBlank(subOp.getIun()))
+                .flatMap(subOp -> enhanceIuns(subOp.getAttachments(), operationResponse))
+                .then(Mono.just(operationResponse));
+    }
+
     private Mono<OperationResponse> enhanceIuns(List<PnServiceDeskAttachments> attachments, OperationResponse operationResponse) {
         return Flux.fromIterable(attachments)
-                   .flatMap(att -> pnDeliveryClient.getSentNotificationPrivate(att.getIun()))
-                   .doOnNext(att -> {
-                       SDNotificationSummary summary = new SDNotificationSummary();
-                       summary.setIun(att.getIun());
-                       summary.setSenderPaInternalId(att.getSenderPaId());
-                       summary.setSenderPaIpaCode("");
-                       summary.setSenderPaTaxCode(att.getSenderTaxId());
-                       summary.setSenderPaDescription(att.getSenderDenomination());
-                       if (Boolean.TRUE.equals(att.getDocumentsAvailable())) {
-                           operationResponse.getIuns().add(summary);
-                       } else {
-                           operationResponse.getUncompletedIuns().add(summary);
-                       }
-                   })
-                   .then(Mono.just(operationResponse));
+                .flatMap(att -> pnDeliveryClient.getSentNotificationPrivate(att.getIun())
+                        .map(sentNotification -> {
+                            SDNotificationSummary summary = new SDNotificationSummary();
+                            summary.setIun(sentNotification.getIun());
+                            summary.setSenderPaInternalId(sentNotification.getSenderPaId());
+                            summary.setSenderPaIpaCode("");
+                            summary.setSenderPaTaxCode(sentNotification.getSenderTaxId());
+                            summary.setSenderPaDescription(sentNotification.getSenderDenomination());
+                            if (Boolean.TRUE.equals(att.getIsAvailable())) {
+                                operationResponse.getIuns().add(summary);
+                            } else {
+                                operationResponse.getUncompletedIuns().add(summary);
+                            }
+                            return sentNotification;
+                        }))
+                .then(Mono.just(operationResponse));
     }
 
     @Override

--- a/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
@@ -271,7 +271,7 @@ public class OperationsServiceImpl implements OperationsService {
         return Flux.fromIterable(subOpIds)
                 .flatMap(operationDAO::getByOperationId)
                 .filter(subOp -> StringUtils.isNotBlank(subOp.getIun()))
-                .flatMap(subOp -> enhanceIuns(subOp.getAttachments(), operationResponse))
+                .flatMap(subOp -> enhanceIuns(Objects.requireNonNullElse(subOp.getAttachments(), new ArrayList<>()), operationResponse))
                 .then(Mono.just(operationResponse));
     }
 

--- a/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
+++ b/src/main/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImpl.java
@@ -269,15 +269,15 @@ public class OperationsServiceImpl implements OperationsService {
 
     private Mono<OperationResponse> enhanceIunsFromSubOperations(List<String> subOpIds, OperationResponse operationResponse) {
         return Flux.fromIterable(subOpIds)
-                .flatMap(operationDAO::getByOperationId)
+                .concatMap(operationDAO::getByOperationId)
                 .filter(subOp -> StringUtils.isNotBlank(subOp.getIun()))
-                .flatMap(subOp -> enhanceIuns(Objects.requireNonNullElse(subOp.getAttachments(), new ArrayList<>()), operationResponse))
+                .concatMap(subOp -> enhanceIuns(Objects.requireNonNullElse(subOp.getAttachments(), new ArrayList<>()), operationResponse))
                 .then(Mono.just(operationResponse));
     }
 
     private Mono<OperationResponse> enhanceIuns(List<PnServiceDeskAttachments> attachments, OperationResponse operationResponse) {
         return Flux.fromIterable(attachments)
-                .flatMap(att -> pnDeliveryClient.getSentNotificationPrivate(att.getIun())
+                .concatMap(att -> pnDeliveryClient.getSentNotificationPrivate(att.getIun())
                         .map(sentNotification -> {
                             SDNotificationSummary summary = new SDNotificationSummary();
                             summary.setIun(sentNotification.getIun());

--- a/src/test/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImplTest.java
+++ b/src/test/java/it/pagopa/pn/service/desk/service/impl/OperationsServiceImplTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static it.pagopa.pn.service.desk.exception.ExceptionTypeEnum.*;
+import static it.pagopa.pn.service.desk.model.OperationStatusEnum.OK;
 import static org.junit.jupiter.api.Assertions.*;
 
 class OperationsServiceImplTest extends BaseTest {
@@ -410,6 +411,63 @@ class OperationsServiceImplTest extends BaseTest {
         SearchNotificationRequest request = new SearchNotificationRequest();
         request.setTaxId("123");
         return request;
+    }
+
+    @Test
+    void searchOperationsFromRecipientInternalId_SubOperationFiltered_NotIncludedInResult() {
+        pnServiceDeskOperations.setIsSubOperation(true);
+        pnServiceDeskOperations.setAttachments(null);
+
+        Mockito.when(operationDAO.searchOperationsFromRecipientInternalId(Mockito.any()))
+                .thenReturn(Flux.just(pnServiceDeskOperations));
+
+        StepVerifier.create(service.searchOperationsFromRecipientInternalId("1234", getNotificationRequest()))
+                .assertNext(response -> {
+                    assertNotNull(response);
+                    assertNotNull(response.getOperations());
+                    assertEquals(0, response.getOperations().size());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void searchOperationsFromRecipientInternalId_WithSubOperationIds_EnhancesIunsFromSubOps() {
+        PnServiceDeskOperations parentOp = pnServiceDeskOperations;
+        parentOp.setSubOperationsIds(List.of("sub1"));
+
+        PnServiceDeskAttachments attachment = new PnServiceDeskAttachments();
+        attachment.setIun("iun-sub");
+        attachment.setIsAvailable(true);
+
+        PnServiceDeskOperations subOp = new PnServiceDeskOperations();
+        subOp.setOperationId("sub1");
+        subOp.setIun("iun-sub");
+        subOp.setStatus(OK.toString());
+        subOp.setAttachments(new ArrayList<>(List.of(attachment)));
+
+        SentNotificationV25Dto sentNotification = new SentNotificationV25Dto();
+        sentNotification.setIun("iun-sub");
+        sentNotification.setSenderPaId("pa-id");
+        sentNotification.setSenderTaxId("pa-tax");
+        sentNotification.setSenderDenomination("pa-name");
+
+        Mockito.when(operationDAO.searchOperationsFromRecipientInternalId(Mockito.any()))
+                .thenReturn(Flux.just(parentOp));
+        Mockito.when(operationDAO.getByOperationId("sub1"))
+                .thenReturn(Mono.just(subOp));
+        Mockito.when(pnDeliveryClient.getSentNotificationPrivate("iun-sub"))
+                .thenReturn(Mono.just(sentNotification));
+
+        StepVerifier.create(service.searchOperationsFromRecipientInternalId("1234", getNotificationRequest()))
+                .assertNext(response -> {
+                    assertNotNull(response);
+                    assertEquals(1, response.getOperations().size());
+                    OperationResponse op = response.getOperations().get(0);
+                    assertNotNull(op.getIuns());
+                    assertEquals(1, op.getIuns().size());
+                    assertEquals("iun-sub", op.getIuns().get(0).getIun());
+                })
+                .verifyComplete();
     }
 
     @Test


### PR DESCRIPTION
   - For v2 operations, the parent doesn't have info on attachments. Get data from subOperations.
   - Use the right boolean variable to populate iuns and uncompletedIuns lists.