### PR TITLE
fix: defer requestToPrepare assembly in EMAIL validation flow to prev…

### DIFF
--- a/src/main/java/it/pagopa/pn/service/desk/action/impl/ValidationOperationActionImpl.java
+++ b/src/main/java/it/pagopa/pn/service/desk/action/impl/ValidationOperationActionImpl.java
@@ -130,10 +130,9 @@ public class ValidationOperationActionImpl extends BaseService implements Valida
                     .flatMap(lstAttachments -> {
                         operation.setAttachments(lstAttachments);
                         return operationDAO.updateEntity(operation)
-                                           .switchIfEmpty(Mono.defer(() -> Mono.error(new PnGenericException(ERROR_ON_UPDATE_ENTITY, ERROR_ON_UPDATE_ENTITY.getMessage()))))
-                                           .thenReturn(operation);
+                                           .switchIfEmpty(Mono.defer(() -> Mono.error(new PnGenericException(ERROR_ON_UPDATE_ENTITY, ERROR_ON_UPDATE_ENTITY.getMessage()))));
                     })
-                    .then(requestToPrepare(operation, address));
+                    .flatMap(op -> requestToPrepare(op, address));
         }
 
         return getIuns(operation.getRecipientInternalId())


### PR DESCRIPTION
…ent NPE

In the EMAIL branch of checkValidationFlow, requestToPrepare was passed as an eager argument to .then(), causing Flux.fromIterable to be called at assembly time before operation.setAttachments() had run, resulting in a NullPointerException when the attachments field was null on the entity.