### PR TITLE
PN-19991: use STRICT ModelMapper strategy in NotificationAndMessageMa…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath />
 	</parent>
 	<artifactId>pn-service-desk</artifactId>
-	<version>1.13.0-RC.2</version>
+	<version>1.13.0</version>
 	<name>pn-service-desk</name>
 	<description>A template for a PN Backend Microservice</description>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath />
 	</parent>
 	<artifactId>pn-service-desk</artifactId>
-	<version>1.13.0</version>
+	<version>1.13.1-SNAPSHOT</version>
 	<name>pn-service-desk</name>
 	<description>A template for a PN Backend Microservice</description>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath />
 	</parent>
 	<artifactId>pn-service-desk</artifactId>
-	<version>1.13.0-RC.1</version>
+	<version>1.13.0-RC.2</version>
 	<name>pn-service-desk</name>
 	<description>A template for a PN Backend Microservice</description>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath />
 	</parent>
 	<artifactId>pn-service-desk</artifactId>
-	<version>1.13.0-SNAPSHOT</version>
+	<version>1.13.0-RC.1</version>
 	<name>pn-service-desk</name>
 	<description>A template for a PN Backend Microservice</description>
 	<scm>

--- a/src/main/java/it/pagopa/pn/service/desk/mapper/NotificationAndMessageMapper.java
+++ b/src/main/java/it/pagopa/pn/service/desk/mapper/NotificationAndMessageMapper.java
@@ -8,6 +8,7 @@ import it.pagopa.pn.service.desk.generated.openapi.msclient.pndeliverypush.v1.dt
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pndeliverypush.v1.dto.TimelineElementV28Dto;
 import it.pagopa.pn.service.desk.generated.openapi.server.v1.dto.*;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.CollectionUtils;
 
@@ -20,7 +21,13 @@ public class NotificationAndMessageMapper {
 
     private NotificationAndMessageMapper(){}
 
-    private static final ModelMapper modelMapper = new ModelMapper();
+    private static final ModelMapper modelMapper = buildModelMapper();
+
+    private static ModelMapper buildModelMapper() {
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        return mapper;
+    }
 
     public static NotificationResponse getNotification (NotificationSearchRowDto notificationSearchRowDto, List<TimelineElementV28Dto> filteredElements){
         NotificationResponse notification = new NotificationResponse();

--- a/src/test/java/it/pagopa/pn/service/desk/mapper/NotificationAndMessageMapperTest.java
+++ b/src/test/java/it/pagopa/pn/service/desk/mapper/NotificationAndMessageMapperTest.java
@@ -3,7 +3,6 @@ package it.pagopa.pn.service.desk.mapper;
 import it.pagopa.pn.service.desk.exception.PnGenericException;
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pndelivery.v1.dto.*;
 import it.pagopa.pn.service.desk.generated.openapi.msclient.pndeliverypush.v1.dto.*;
-import it.pagopa.pn.service.desk.generated.openapi.msclient.pndeliverypush.v1.dto.NotificationStatusV26Dto;
 import it.pagopa.pn.service.desk.generated.openapi.server.v1.dto.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +46,7 @@ class NotificationAndMessageMapperTest {
         filteredElements.add(timelineElementV23Dto);
         var allTimelines = List.of(timelineElementV23Dto, refinement);
         historyResponseDto.setTimeline(allTimelines);
-        historyResponseDto.setNotificationStatus(NotificationStatusV26Dto.ACCEPTED);
+        historyResponseDto.setNotificationStatus(it.pagopa.pn.service.desk.generated.openapi.msclient.pndeliverypush.v1.dto.NotificationStatusV26Dto.ACCEPTED);
         notificationAttachmentDownloadMetadataResponseDto.setFilename("document_test");
         notificationAttachmentDownloadMetadataResponseDto.setContentType("test");
         notificationAttachmentDownloadMetadataResponseDto.setContentLength(1200);
@@ -265,17 +264,26 @@ class NotificationAndMessageMapperTest {
 
     @Test
     void getTimelineDoesNotThrowOnSendAnalogDomicile() {
+        Instant eventTimestamp = Instant.now();
+
         TimelineElementV28Dto element = new TimelineElementV28Dto();
         element.setCategory(TimelineElementCategoryV28Dto.SEND_ANALOG_DOMICILE);
+        element.setEventTimestamp(eventTimestamp);
         element.setDetails(new SendAnalogDetailsDto()
                 .prepareRequestId("prep-1")
                 .relatedRequestId("rel-1"));
 
         NotificationHistoryResponseDto history = new NotificationHistoryResponseDto();
-        history.setNotificationStatus(NotificationStatusV26Dto.ACCEPTED);
+        history.setNotificationStatus(it.pagopa.pn.service.desk.generated.openapi.msclient.pndeliverypush.v1.dto.NotificationStatusV26Dto.ACCEPTED);
         history.setTimeline(List.of(element));
 
-        assertDoesNotThrow(() -> NotificationAndMessageMapper.getTimeline(history));
+        TimelineResponse response = assertDoesNotThrow(() -> NotificationAndMessageMapper.getTimeline(history));
+
+        assertThat(response.getTimeline()).hasSize(1);
+        TimelineElementDetail detail = response.getTimeline().get(0).getDetail();
+        assertNotNull(detail);
+        assertEquals("prep-1", detail.getPrepareRequestId());
+        assertEquals("rel-1", detail.getRelatedRequestId());
     }
 
 }

--- a/src/test/java/it/pagopa/pn/service/desk/mapper/NotificationAndMessageMapperTest.java
+++ b/src/test/java/it/pagopa/pn/service/desk/mapper/NotificationAndMessageMapperTest.java
@@ -263,4 +263,19 @@ class NotificationAndMessageMapperTest {
                   );
     }
 
+    @Test
+    void getTimelineDoesNotThrowOnSendAnalogDomicile() {
+        TimelineElementV28Dto element = new TimelineElementV28Dto();
+        element.setCategory(TimelineElementCategoryV28Dto.SEND_ANALOG_DOMICILE);
+        element.setDetails(new SendAnalogDetailsDto()
+                .prepareRequestId("prep-1")
+                .relatedRequestId("rel-1"));
+
+        NotificationHistoryResponseDto history = new NotificationHistoryResponseDto();
+        history.setNotificationStatus(NotificationStatusV26Dto.ACCEPTED);
+        history.setTimeline(List.of(element));
+
+        assertDoesNotThrow(() -> NotificationAndMessageMapper.getTimeline(history));
+    }
+
 }


### PR DESCRIPTION
…pper

The default STANDARD matching strategy raises ConfigurationException on GET timeline for SEND_ANALOG_DOMICILE elements: SendAnalogDetailsDto exposes both prepareRequestId and relatedRequestId, which become ambiguous partial matches for the destination setSendRequestId setter on TimelineElementDetail (flat union of all oneOf subtypes).